### PR TITLE
Handle PKCS12Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ruby-version

--- a/lib/passbook/config.rb
+++ b/lib/passbook/config.rb
@@ -43,7 +43,7 @@ module Passbook
 
     def validate_config
       self.pass_config.values.each do |config|
-        validator = PassConfig::Validator.new config
+        validator = Passbook::Validators::PassConfig.new config
         error validator.error unless validator.valid?
       end
     end

--- a/lib/passbook/config.rb
+++ b/lib/passbook/config.rb
@@ -13,16 +13,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
-
-
 require 'fileutils'
 require 'singleton'
 
 module Passbook
   class Config
     include Singleton
-    attr_accessor :pass_config, :wwdr_intermediate_certificate_path, :wwdr_certificate, :preload_template, :enable_routes
+
+    attr_accessor :pass_config,
+                  :wwdr_intermediate_certificate_path,
+                  :wwdr_certificate,
+                  :preload_template,
+                  :enable_routes
 
     def configure
       self.pass_config = Hash.new unless self.pass_config
@@ -34,20 +36,27 @@ module Passbook
       self.pass_config = Hash.new unless self.pass_config
       yield self
       self.preload_template ||= ::Rails.env.production? if defined? ::Rails
+      validate_config
       read_templates if self.preload_template
       read_p12_certificates
     end
 
-    # @private
-    def read_templates
-      self.pass_config.each do |pass_type_id, config|
-        raise(ArgumentError, "Please specify a template_path in your configuration (in initializer)") unless config['template_path']
-        config['files']||= load_files config['template_path']
+    def validate_config
+      self.pass_config.values.each do |config|
+        validator = PassConfig::Validator.new config
+        error validator.error unless validator.valid?
       end
     end
 
-    def load_files path
+    def read_templates
+      self.pass_config.values.each do |config|
+        config['files'] ||= load_files config['template_path']
+      end
+    end
+
+    def load_files(path)
       files = {}
+
       Dir.glob(path+"/**/**").each do |file_path|
         next if File.directory? file_path
         filename = Pathname.new(file_path).relative_path_from(Pathname.new(path))
@@ -57,21 +66,27 @@ module Passbook
       files
     end
 
-    # @private
     def read_p12_certificates
-      pass_config.each do |pass_type_id, config|
-        raise(ArgumentError, "Please specify cert_path (certificate path) in your configuration (in initializer)") unless config['cert_path'] && !config['cert_path'].blank?
-        raise(ArgumentError, "Please specify cert_password (certificate password) in your configuration (in initializer)") unless config['cert_password']
-        config['p12_certificate'] ||=  OpenSSL::PKCS12::new(File.read(config['cert_path']), config['cert_password'])
+      pass_config.values.each do |config|
+        config['p12_certificate'] ||= read_p12_certificate(config)
       end
     end
 
-    # @private
     def read_wwdr_certificate
       # raise(ArgumentError, "Please specify the WWDR Intermediate certificate in your initializer") unless self.wwdr_intermediate_certificate_path
       self.wwdr_certificate||= OpenSSL::X509::Certificate.new(File.read(self.wwdr_intermediate_certificate_path))
     end
 
+    def error(message, kind = ArgumentError)
+      raise kind, message
+    end
+
+    def read_p12_certificate(config)
+      file = File.read config['cert_path']
+      OpenSSL::PKCS12::new file, config['cert_password']
+    rescue OpenSSL::PKCS12::PKCS12Error => error
+      error "#{error.message} - Verify cert_password in your config is correct"
+    end
   end
 end
 

--- a/lib/passbook/config.rb
+++ b/lib/passbook/config.rb
@@ -15,6 +15,7 @@
 
 require 'fileutils'
 require 'singleton'
+require 'passbook/validators/pass_config'
 
 module Passbook
   class Config

--- a/lib/passbook/config.rb
+++ b/lib/passbook/config.rb
@@ -13,16 +13,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
-
-
 require 'fileutils'
 require 'singleton'
 
 module Passbook
   class Config
     include Singleton
-    attr_accessor :pass_config, :wwdr_intermediate_certificate_path, :wwdr_certificate, :preload_template, :enable_routes
+
+    attr_accessor :pass_config,
+                  :wwdr_intermediate_certificate_path,
+                  :wwdr_certificate,
+                  :preload_template,
+                  :enable_routes
 
     def configure
       self.pass_config = Hash.new unless self.pass_config
@@ -34,20 +36,27 @@ module Passbook
       self.pass_config = Hash.new unless self.pass_config
       yield self
       self.preload_template ||= ::Rails.env.production? if defined? ::Rails
+      validate_config
       read_templates if self.preload_template
       read_p12_certificates
     end
 
-    # @private
-    def read_templates
-      self.pass_config.each do |pass_type_id, config|
-        raise(ArgumentError, "Please specify a template_path in your configuration (in initializer)") unless config['template_path']
-        config['files']||= load_files config['template_path']
+    def validate_config
+      self.pass_config.values.each do |config|
+        validator = Passbook::Validators::PassConfig.new config
+        error validator.error unless validator.valid?
       end
     end
 
-    def load_files path
+    def read_templates
+      self.pass_config.values.each do |config|
+        config['files'] ||= load_files config['template_path']
+      end
+    end
+
+    def load_files(path)
       files = {}
+
       Dir.glob(path+"/**/**").each do |file_path|
         next if File.directory? file_path
         filename = Pathname.new(file_path).relative_path_from(Pathname.new(path))
@@ -57,21 +66,27 @@ module Passbook
       files
     end
 
-    # @private
     def read_p12_certificates
-      pass_config.each do |pass_type_id, config|
-        raise(ArgumentError, "Please specify cert_path (certificate path) in your configuration (in initializer)") unless config['cert_path'] && !config['cert_path'].blank?
-        raise(ArgumentError, "Please specify cert_password (certificate password) in your configuration (in initializer)") unless config['cert_password']
-        config['p12_certificate'] ||=  OpenSSL::PKCS12::new(File.read(config['cert_path']), config['cert_password'])
+      pass_config.values.each do |config|
+        config['p12_certificate'] ||= read_p12_certificate(config)
       end
     end
 
-    # @private
     def read_wwdr_certificate
       # raise(ArgumentError, "Please specify the WWDR Intermediate certificate in your initializer") unless self.wwdr_intermediate_certificate_path
       self.wwdr_certificate||= OpenSSL::X509::Certificate.new(File.read(self.wwdr_intermediate_certificate_path))
     end
 
+    def error(message, kind = ArgumentError)
+      raise kind, message
+    end
+
+    def read_p12_certificate(config)
+      file = File.read config['cert_path']
+      OpenSSL::PKCS12::new file, config['cert_password']
+    rescue OpenSSL::PKCS12::PKCS12Error => error
+      error "#{error.message} - Verify cert_password in your config is correct"
+    end
   end
 end
 

--- a/lib/passbook/validators/pass_config.rb
+++ b/lib/passbook/validators/pass_config.rb
@@ -1,7 +1,7 @@
 module Passbook
-  module PassConfig
-    class Validator
-      REQUIRED = %i(cert_path cert_password template_path).freeze
+  module Validators
+    class PassConfig
+      REQUIRED = %w(cert_path cert_password template_path).freeze
       attr_reader :error
 
       def initialize(config_attrs)
@@ -14,6 +14,8 @@ module Passbook
       end
 
       private
+
+      attr_reader :config_attrs
 
       def present?(attr)
         if config_attrs[attr].present? # no empty string!

--- a/lib/passbook/validators/validator.rb
+++ b/lib/passbook/validators/validator.rb
@@ -1,0 +1,28 @@
+module Passbook
+  module PassConfig
+    class Validator
+      REQUIRED = %i(cert_path cert_password template_path).freeze
+      attr_reader :error
+
+      def initialize(config_attrs)
+        @config_attrs = config_attrs
+        @error = ''
+      end
+
+      def valid?
+        REQUIRED.all? { |attr| present? attr }
+      end
+
+      private
+
+      def present?(attr)
+        if config_attrs[attr].present? # no empty string!
+          true
+        else
+          @error = "#{attr} is required in your config"
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -13,33 +13,65 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
-
-
 require 'spec_helper'
 
-describe Passbook::Config do
-  # it "should throw ArgumentError because wwdr_intermediate_certificate_path is missing"  do
-  #   expect {Passbook::Config.instance.configure {}}.to raise_error(ArgumentError)
-  # end
+module Passbook
+  describe Config do
+    # it "should throw ArgumentError because wwdr_intermediate_certificate_path is missing"  do
+    #   expect {Passbook::Config.instance.configure {}}.to raise_error(ArgumentError)
+    # end
 
-  it "should throw ArgumentError because cert_path is missing" do
-    expect{ Passbook::Config.instance.add_pkpass do |passbook|
-      passbook.wwdr_intermediate_certificate_path = "test"
-      passbook.wwdr_certificate = OpenSSL::X509::Certificate.new
-      passbook.pass_config["pass.com.acme"] = {"template_path"=>"tmp"}
-    end}.to raise_error(ArgumentError)
+    it 'should throw ArgumentError because cert_path is missing' do
+      expect {
+        Passbook::Config.instance.add_pkpass do |passbook|
+          passbook.wwdr_intermediate_certificate_path = 'test'
+          passbook.wwdr_certificate = OpenSSL::X509::Certificate.new
+          passbook.pass_config['pass.com.acme'] = {
+            'cert_password' => 'foo',
+            'template_path' =>'tmp'
+          }
+        end
+      }.to raise_error(ArgumentError, 'cert_path is required in your config')
+    end
+
+    it 'should throw ArgumentError because cert_password is missing' do
+      expect {
+        Passbook::Config.instance.add_pkpass do |passbook|
+          passbook.wwdr_intermediate_certificate_path = 'test'
+          passbook.wwdr_certificate = OpenSSL::X509::Certificate.new
+          passbook.pass_config['pass.com.acme'] = {
+            'cert_path' =>'tmp',
+            'template_path' =>'tmp'
+          }
+        end
+      }.to raise_error(ArgumentError, 'cert_password is required in your config')
+    end
+
+    it 'throws ArgumentError when template_password is missing' do
+      expect {
+        Passbook::Config.instance.add_pkpass do |passbook|
+          passbook.wwdr_intermediate_certificate_path = 'test'
+          passbook.wwdr_certificate = OpenSSL::X509::Certificate.new
+          passbook.pass_config['pass.com.acme'] = {
+            'cert_path' =>'tmp',
+            'cert_password' => 'haha'
+          }
+        end
+      }.to raise_error(ArgumentError, 'template_path is required in your config')
+    end
+
+    it 'throws no errors when required config settings are present' do
+      expect {
+        Passbook::Config.instance.add_pkpass do |passbook|
+          passbook.wwdr_intermediate_certificate_path = 'test'
+          passbook.wwdr_certificate = OpenSSL::X509::Certificate.new
+          passbook.pass_config['pass.com.acme'] = {
+            'cert_path' => 'tmp',
+            'cert_password' => 'haha',
+            'template_path' =>'tmp'
+          }
+        end
+      }.not_to raise_error(ArgumentError)
+    end
   end
-
-  it "should throw ArgumentError because cert_password is missing" do
-    expect{ Passbook::Config.instance.add_pkpass do |passbook|
-      passbook.wwdr_intermediate_certificate_path = "test"
-      passbook.wwdr_certificate = OpenSSL::X509::Certificate.new
-      passbook.pass_config["pass.com.acme"] = {
-                                                "cert_path"=>"tmp"
-                                              }
-    end}.to raise_error(ArgumentError)
-  end
-
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ require "rails/test_help"
 require_relative '../lib/passbook-ruby'
 require_relative '../lib/passbook/config'
 require_relative '../lib/passbook/pkpass'
-
+require_relative '../lib/passbook/validators/pass_config'
 
 module Helpers
 

--- a/spec/validators/pass_config_spec.rb
+++ b/spec/validators/pass_config_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+module Passbook
+  module Validators
+    describe PassConfig, '#valid?' do
+      it 'requires cert_path' do
+        attrs = { foo: 'bar' }
+        validator = described_class.new attrs
+
+        expect(validator).not_to be_valid
+        expect(validator.error).to eq('cert_path is required in your config')
+      end
+
+      it 'requires cert_password' do
+        attrs = { cert_path: 'bar' }
+        validator = described_class.new attrs
+
+        expect(validator).not_to be_valid
+        expect(validator.error).to eq('cert_password is required in your config')
+      end
+
+      it 'requires template_path' do
+        attrs = { cert_path: 'bar', cert_password: 'foo' }
+        validator = described_class.new attrs
+
+        expect(validator).not_to be_valid
+        expect(validator.error).to eq('template_path is required in your config')
+      end
+
+      it 'is valid when required fields are defined' do
+        attrs = { cert_path: 'bar', cert_password: 'foo', template_path: 'ha' }
+        expect(described_class.new attrs).to be_valid
+      end
+    end
+  end
+end

--- a/spec/validators/pass_config_spec.rb
+++ b/spec/validators/pass_config_spec.rb
@@ -4,7 +4,7 @@ module Passbook
   module Validators
     describe PassConfig, '#valid?' do
       it 'requires cert_path' do
-        attrs = { foo: 'bar' }
+        attrs = { 'foo' => 'bar' }
         validator = described_class.new attrs
 
         expect(validator).not_to be_valid
@@ -12,7 +12,7 @@ module Passbook
       end
 
       it 'requires cert_password' do
-        attrs = { cert_path: 'bar' }
+        attrs = { 'cert_path' => 'bar' }
         validator = described_class.new attrs
 
         expect(validator).not_to be_valid
@@ -20,7 +20,7 @@ module Passbook
       end
 
       it 'requires template_path' do
-        attrs = { cert_path: 'bar', cert_password: 'foo' }
+        attrs = { 'cert_path' => 'bar', 'cert_password' => 'foo' }
         validator = described_class.new attrs
 
         expect(validator).not_to be_valid
@@ -28,7 +28,7 @@ module Passbook
       end
 
       it 'is valid when required fields are defined' do
-        attrs = { cert_path: 'bar', cert_password: 'foo', template_path: 'ha' }
+        attrs = { 'cert_path' => 'bar', 'cert_password' => 'foo', 'template_path' => 'ha' }
         expect(described_class.new attrs).to be_valid
       end
     end


### PR DESCRIPTION
This makes the error much more developer friendly when the password in the config doesn't match the P12 certificate. I also mildly refactored the config validation my creating a new validator for pass configs.

![screen shot 2016-02-02 at 3 51 40 pm](https://cloud.githubusercontent.com/assets/1714100/12768517/ee4435b8-c9c4-11e5-9702-c76605d678a0.png)
